### PR TITLE
adding Hypothesis proxy to all annotation links

### DIFF
--- a/hypothesis-aggregator.php
+++ b/hypothesis-aggregator.php
@@ -135,7 +135,7 @@ function hypothesis_shortcode( $atts ) {
 
 						}
 						$account = $annotation_local->user;
-						$output .= 'Curated by <a href="';
+						$output .= 'Curated by <a href="http://via.hypothes.is/';
 						$output .= "https://hypothes.is/stream?q=user:";
 						list($dump1, $account_name, $dump2) = split('[:@]', $account);
 						$output .= $account_name;


### PR DESCRIPTION
The proxy enables users that click on links use Hypothesis even if they don't already have the Hypothesis client (eg, as a Chrome extension).